### PR TITLE
Update README for Alpine 3.9 usage with proper execution rights

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,5 +31,6 @@ COPY wkhtmltopdf /usr/bin/wkhtmltopdf
 # add openssl dependencies
 RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.8/main' >> /etc/apk/repositories && \
     apk add --no-cache libcrypto1.0 libssl1.0 && \
+    chmod +x /usr/bin/wkhtmltopdf && \
     /usr/bin/wkhtmltopdf --version
 ```


### PR DESCRIPTION
On Linux I got a permission denied error when running `/usr/bin/wkhtmltopdf --version` for Alpine 3.9 because execution rights are missing after copying the patched wkhtmltopdf binary. Adding proper execution rights for the wkhtmltopdf binary fixes the problem.

BTW thanks for this useful code, it saved me a lot of time.